### PR TITLE
Update SkipContract.sol

### DIFF
--- a/step04_chap2_textbook/contracts/SkipContract.sol
+++ b/step04_chap2_textbook/contracts/SkipContract.sol
@@ -42,12 +42,12 @@ contract SkipContract {
     function getSkipFunction(uint _fnNumber)
         internal
         pure
-        returns (function(uint) pure returns(uint))
+        returns (function(uint) pure returns(uint) func) 
     {
         if (_fnNumber == 1) {
-            return skip1;
+            func = skip_1;
         } else if (_fnNumber == 2) {
-            return skip2;
+            func = skip_2;
         }
     }
 


### PR DESCRIPTION
Fix to avoid below warning

Warning: Unnamed return variable can remain unassigned. Add an explicit return with value to all non-reverting code paths or name the variable.
  --> contracts/SkipContract.sol:26:6:
   |
26 |     (function(uint) pure returns(uint) ) {
   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^